### PR TITLE
 'rimraf dist' to 'rimraf public'

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "node server",
     "start": "cross-env NODE_ENV=production node server",
-    "build": "rimraf dist && npm run build:client && npm run build:server",
+    "build": "rimraf public && npm run build:client && npm run build:server",
     "build:client": "cross-env NODE_ENV=production webpack --config build/webpack.client.config.js --progress --hide-modules",
     "build:server": "cross-env NODE_ENV=production webpack --config build/webpack.server.config.js --progress --hide-modules"
   },


### PR DESCRIPTION
Rather than creating a new 'dist' folder, I changed the 'build' script to rimraf public folder, which, in this case, the folder already exists.